### PR TITLE
htmlpurifier should be installed by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,7 @@
     "qcubed/composer": "dev-master"
   },
   "require-dev": {
-    "lastcraft/simpletest": "dev-master"
-  },
-  "suggest": {
+    "lastcraft/simpletest": "dev-master",
     "ezyang/htmlpurifier": "dev-master"
   },
   "minimum-stability":"dev"


### PR DESCRIPTION
htmlpurifier is used in examples and should be installed by default

see issue https://github.com/qcubed/framework/issues/869:
- assets/php/examples/basic_qform/xss.php

```
Error in PHP Script /example.com/vendor/qcubed/framework/assets/php/examples/basic_qform/xss.php
require_once(/var/www/example.com/vendor/ezyang/htmlpurifier/library/HTMLPurifier.auto.php): failed to open stream: No such file or directory
```

htmlpurifier should be required by the composer file?
